### PR TITLE
Fix line numbers for multiple files

### DIFF
--- a/03_catr/src/lib.rs
+++ b/03_catr/src/lib.rs
@@ -51,15 +51,16 @@ pub fn get_args() -> MyResult<Config> {
 
 // --------------------------------------------------
 pub fn run(config: Config) -> MyResult<()> {
+    let mut last_num = 0;
     for filename in config.files {
         match open(&filename) {
             Err(e) => eprintln!("{}: {}", filename, e),
             Ok(file) => {
-                let mut last_num = 0;
-                for (line_num, line_result) in file.lines().enumerate() {
+                for line_result in file.lines() {
                     let line = line_result?;
                     if config.number_lines {
-                        println!("{:6}\t{}", line_num + 1, line);
+                        last_num += 1;
+                        println!("{:6}\t{}", last_num, line);
                     } else if config.number_nonblank_lines {
                         if !line.is_empty() {
                             last_num += 1;

--- a/03_catr/tests/expected/all.b.out
+++ b/03_catr/tests/expected/all.b.out
@@ -1,13 +1,13 @@
      1	The quick brown fox jumps over the lazy dog.
-     1	Don't worry, spiders,
-     2	I keep house
-     3	casually.
-     1	The bustle in a house
-     2	The morning after death
-     3	Is solemnest of industries
-     4	Enacted upon earth,—
+     2	Don't worry, spiders,
+     3	I keep house
+     4	casually.
+     5	The bustle in a house
+     6	The morning after death
+     7	Is solemnest of industries
+     8	Enacted upon earth,—
 
-     5	The sweeping up the heart,
-     6	And putting love away
-     7	We shall not want to use again
-     8	Until eternity.
+     9	The sweeping up the heart,
+    10	And putting love away
+    11	We shall not want to use again
+    12	Until eternity.

--- a/03_catr/tests/expected/all.n.out
+++ b/03_catr/tests/expected/all.n.out
@@ -1,13 +1,13 @@
      1	The quick brown fox jumps over the lazy dog.
-     1	Don't worry, spiders,
-     2	I keep house
-     3	casually.
-     1	The bustle in a house
-     2	The morning after death
-     3	Is solemnest of industries
-     4	Enacted upon earth,—
-     5	
-     6	The sweeping up the heart,
-     7	And putting love away
-     8	We shall not want to use again
-     9	Until eternity.
+     2	Don't worry, spiders,
+     3	I keep house
+     4	casually.
+     5	The bustle in a house
+     6	The morning after death
+     7	Is solemnest of industries
+     8	Enacted upon earth,—
+     9	
+    10	The sweeping up the heart,
+    11	And putting love away
+    12	We shall not want to use again
+    13	Until eternity.


### PR DESCRIPTION
This fixes the differences to the `cat` implementation for multiple files. See https://github.com/kyclark/command-line-rust/issues/9

Unfortunately, I haven't found a fix while still using enumerate. So, this kind of deviates from the text in the book.