### PR TITLE
Create mk-outs script for Windows

### DIFF
--- a/02_echor/mk-outs.ps1
+++ b/02_echor/mk-outs.ps1
@@ -1,0 +1,9 @@
+$OUTDIR = "tests\expected"
+if (-not (Test-Path $OUTDIR)) {
+    New-Item -ItemType Directory -Path $OUTDIR | Out-Null
+}
+
+"Hello there" | Out-File -FilePath "$OUTDIR\hello1.txt"
+"Hello", "there" -join ' ' | Out-File -FilePath "$OUTDIR\hello2.txt"
+"Hello  there" | Out-File -FilePath "$OUTDIR\hello1.n.txt" -NoNewline
+"Hello", "there" -join ' ' | Out-File -FilePath "$OUTDIR\hello2.n.txt" -NoNewline


### PR DESCRIPTION
I'm reading Command-Line Rust.
When I follow each phase in echor need to copy all generated test case file in Windows.
Surly it's possible but I just rewrite mk-outs script as PowerShell script.